### PR TITLE
feat: Mejorar la gestión de Porcinos añadiendo manejo detallado del h…

### DIFF
--- a/frontend/src/components/EditarHistorialModal.js
+++ b/frontend/src/components/EditarHistorialModal.js
@@ -1,10 +1,11 @@
+// frontendsrc/components/EditarHistorialModal.js
 import React, { useEffect, useState } from 'react';
 import Modal from 'react-modal';
 import Swal from 'sweetalert2';
 import { useEditarHistorial } from '../hooks/useEditarHistorial';
 
 export default function EditarHistorialModal({ isOpen, onRequestClose, porcino, registro, onGuardado }) {
-  const { alimentaciones, editar } = useEditarHistorial();
+  const { alimentaciones, editar } = useEditarHistorial(); // usa queries/mutations GraphQL [attached_file:1]
   const [form, setForm] = useState({ alimentacionId: '', dosis: '' });
   const [loading, setLoading] = useState(false);
 
@@ -12,54 +13,61 @@ export default function EditarHistorialModal({ isOpen, onRequestClose, porcino, 
     if (isOpen && registro) {
       setForm({
         alimentacionId: registro?.alimentacion?._id || '',
-        dosis: registro?.dosis || ''
+        dosis: registro?.dosis ?? '',
       });
     }
-  }, [isOpen, registro]);
+  }, [isOpen, registro]); // [attached_file:1]
 
   function handleChange(e) {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const { name, value } = e.target;
+    setForm((s) => ({ ...s, [name]: value }));
   }
 
-async function save(e) {
-  e.preventDefault();
+  async function save(e) {
+    e.preventDefault();
+    // Si el registro es de solo lectura, no intentar guardar
+    const existeAlim = Boolean(registro?.alimentacion?._id);
+    if (!existeAlim) {
+      return Swal.fire('Aviso', 'Este registro es de solo lectura porque la alimentación original fue eliminada.', 'info'); // [attached_file:1]
+    }
+    if (!porcino?._id || !registro?._id) {
+      return Swal.fire('Error', 'No se encontró el porcino o el registro a editar.', 'error'); // [attached_file:1]
+    }
+    if (!form.alimentacionId) {
+      return Swal.fire('Error', 'Seleccione alimentación.', 'error'); // [attached_file:1]
+    }
+    const dosisNum = Number(form.dosis);
+    if (!dosisNum || dosisNum <= 0) {
+      return Swal.fire('Error', 'Dosis debe ser mayor que 0.', 'error'); // [attached_file:1]
+    }
 
-  if (!porcino?._id || !registro?._id) {
-    return Swal.fire('Error', 'No se encontró el porcino o el registro a editar.', 'error');
-  }
-  if (!form.alimentacionId) {
-    return Swal.fire('Error', 'Seleccione alimentación.', 'error');
-  }
-  if (!form.dosis || Number(form.dosis) <= 0) {
-    return Swal.fire('Error', 'Dosis debe ser mayor que 0.', 'error');
-  }
-
-  setLoading(true);
-  try {
-    await editar({
-      variables: {
-        porcinoId: porcino._id,
-        historialId: registro._id,
-        data: {
-          alimentacionId: form.alimentacionId,
-          dosis: Number(form.dosis),
-          // si agregas fecha editable: fecha: new Date(form.fecha).toISOString()
+    setLoading(true);
+    try {
+      await editar({
+        variables: {
+          porcinoId: porcino._id,
+          historialId: registro._id,
+          data: {
+            alimentacionId: String(form.alimentacionId),
+            dosis: dosisNum,
+            // fecha: new Date(form.fecha).toISOString(),
+          },
         },
-      },
-    });
-    await Swal.fire('Listo', 'Historial actualizado.', 'success');
-    onGuardado?.();
-    onRequestClose?.();
-  } catch (err) {
-    const msg = err?.graphQLErrors?.[0]?.message || err?.message || 'No se pudo actualizar el historial.';
-    return Swal.fire('Error', msg, 'error');
-  } finally {
-    setLoading(false);
+      });
+      await Swal.fire('Listo', 'Historial actualizado.', 'success'); // [attached_file:1]
+      onGuardado?.(); // refetch en padre si aplica [attached_file:1]
+      onRequestClose?.();
+    } catch (err) {
+      const msg = err?.graphQLErrors?.[0]?.message || err?.message || 'No se pudo actualizar el historial.'; // [attached_file:1]
+      // Errores esperados desde resolvers: solo lectura, stock insuficiente, alimentacion no encontrada
+      return Swal.fire('Error', msg, 'error'); // [attached_file:1]
+    } finally {
+      setLoading(false);
+    }
   }
-}
 
   const existeAlim = Boolean(registro?.alimentacion?._id);
-  const alims = alimentaciones.data?.alimentaciones || [];
+  const alims = alimentaciones.data?.alimentaciones || []; // lista GraphQL [attached_file:1]
 
   return (
     <Modal isOpen={isOpen} onRequestClose={onRequestClose} ariaHideApp={false}>
@@ -67,9 +75,15 @@ async function save(e) {
         <>
           <h3>Editar registro de alimentación</h3>
           <form onSubmit={save}>
-            <select name="alimentacionId" value={form.alimentacionId} onChange={handleChange} required>
+            <select
+              name="alimentacionId"
+              value={form.alimentacionId}
+              onChange={handleChange}
+              required
+              disabled={loading}
+            >
               <option value="">Seleccione alimentación</option>
-              {alims.map(a => (
+              {alims.map((a) => (
                 <option key={a._id} value={a._id}>
                   {a.nombre}
                 </option>
@@ -84,6 +98,7 @@ async function save(e) {
               min="0.1"
               step="0.1"
               required
+              disabled={loading}
             />
             <button type="submit" disabled={loading}>
               {loading ? 'Guardando...' : 'Guardar'}
@@ -100,8 +115,15 @@ async function save(e) {
             La alimentación original fue eliminada. Se conserva el nombre histórico:{' '}
             <strong>{registro?.nombreSnapshot || 'Alimento (histórico)'}</strong>.
           </p>
-          <p>Dosis: <strong>{registro?.dosis}</strong> lbs</p>
-          <p>Fecha: <strong>{registro?.fecha ? new Date(registro.fecha).toLocaleDateString() : '-'}</strong></p>
+          <p>
+            Dosis: <strong>{registro?.dosis}</strong> lbs
+          </p>
+          <p>
+            Fecha:{' '}
+            <strong>
+              {registro?.fecha ? new Date(registro.fecha).toLocaleDateString() : '-'}
+            </strong>
+          </p>
           <button type="button" onClick={onRequestClose}>Cerrar</button>
         </>
       )}

--- a/frontend/src/components/PorcinoCrud.js
+++ b/frontend/src/components/PorcinoCrud.js
@@ -36,21 +36,20 @@ export default function PorcinoCRUD() {
 
   const [histModalOpen, setHistModalOpen] = useState(false);
   const [porcinoHist, setPorcinoHist] = useState(null);
-
-
-  const [eliminarHist] = useMutation(M_ELIMINAR_HISTORIAL, {
-  refetchQueries: [{ query: Q_PORCINOS }],
-  awaitRefetchQueries: true,
+const [eliminarHist] = useMutation(M_ELIMINAR_HISTORIAL, {
   update(cache, { data }) {
     const porc = data?.eliminarHistorialAlimentacion;
     if (!porc) return;
-    const prev = cache.readQuery({ query: Q_PORCINOS }) || { porcinos: [] };
+    const prev = cache.readQuery({ query: Q_PORCINOS });
+    if (!prev?.porcinos) return;
     cache.writeQuery({
       query: Q_PORCINOS,
       data: { porcinos: prev.porcinos.map(p => (p._id === porc._id ? porc : p)) },
     });
   },
 });
+
+
 
   // Sincronizar resultados de GraphQL con estados de UI
   useEffect(() => {
@@ -101,14 +100,27 @@ export default function PorcinoCRUD() {
       return Swal.fire('Error', msg, 'error');
     }
   }
-  async function onEliminarClick(porcinoId, historialId) {
+
+async function onEliminarClick(porcinoId, historialId) {
+  if (!porcinoId || !historialId) {
+    return Swal.fire('Error', 'No se encontró el identificador del registro de historial.', 'error');
+  }
   const ok = await Swal.fire({ title: 'Eliminar registro?', icon: 'warning', showCancelButton: true });
   if (!ok.isConfirmed) return;
-  await eliminarHist({ variables: { porcinoId, historialId } });
-  Swal.fire('Eliminado', 'Registro removido del historial.', 'success');
+
+  const { data } = await eliminarHist({ variables: { porcinoId, historialId } });
+  const porcUpdated = data?.eliminarHistorialAlimentacion;
+  if (porcUpdated) {
+    // 1) Actualiza la cache de la tabla
+    const prev = qPorcinos.data?.porcinos || [];
+    setPorcinos(prev.map(p => (p._id === porcUpdated._id ? porcUpdated : p)));
+    // 2) Si el modal está abierto y es el mismo porcino, refresca su estado
+    setPorcinoHist((curr) => (curr && curr._id === porcUpdated._id ? porcUpdated : curr));
+  }
+  // 3) Refresca stock para ver cambio en selects (si hay vista de stock)
+  qAlims.refetch();
+  await Swal.fire('Eliminado', 'Registro removido del historial.', 'success');
 }
-
-
 
 
   function edit(p) {
@@ -129,7 +141,8 @@ export default function PorcinoCRUD() {
     setEditHistOpen(true);
   }
 
-  async function eliminarRegistroHist(p, reg) {
+async function eliminarRegistroHist(p, reg) {
+    // Reemplazado por onEliminarClick
     const ok = await Swal.fire({
       title: '¿Eliminar registro?',
       icon: 'warning',
@@ -137,13 +150,15 @@ export default function PorcinoCRUD() {
       confirmButtonText: 'Sí, eliminar',
       cancelButtonText: 'Cancelar',
       customClass: { confirmButton: 'btn btn-danger', cancelButton: 'btn btn-outline' },
-      buttonsStyling: false
+      buttonsStyling: false,
     });
     if (!ok.isConfirmed) return;
+    await eliminarHist({ variables: { porcinoId: p._id, historialId: reg._id } });
+    await Swal.fire('Eliminado', 'Registro removido del historial.', 'success');
+    qPorcinos.refetch();
+  }
 
   
-    return Swal.fire('Pendiente', 'La edición/eliminación granular del historial se expone por REST. Se puede añadir como mutations GraphQL si lo necesitas.', 'info');
-  }
 
   async function del(id) {
     const confirm = await Swal.fire({
@@ -338,8 +353,10 @@ export default function PorcinoCRUD() {
 <div style={{ display:'flex', gap:8, flexWrap:'wrap' }}>
   <button className="icon-btn primary" onClick={() => abrirModalAlimentar(p)} title="Agregar alimentación">🌾➕</button>
   <button className="icon-btn" onClick={() => edit(p)} title="Editar">✏️</button>
+   <button className="btn btn-danger" onClick={() => del(p._id)} title="Eliminar porcino">🗑️</button>
   <button className="icon-btn" onClick={() => abrirHistorialModal(p)} title="Ver historial">📜</button>
-  <button className="btn btn-danger" onClick={() => del(p._id)} title="Eliminar porcino">🗑️</button>
+ 
+
 </div>
                 </td>
               </tr>
@@ -398,14 +415,29 @@ export default function PorcinoCRUD() {
       <td>{h.nombreSnapshot || 'Alimento (histórico)'}</td>
       <td>{h.dosis}</td>
       <td>{new Date(h.fecha).toLocaleDateString()}</td>
-      <td>
-        <div style={{ display:'flex', gap:8 }}>
-          <button className="icon-btn danger"
-                  onClick={() => onEliminarClick(porcinoHist._id, h._id)}
-                  title="Eliminar">🗑️</button>
-          {/* Si habilitas edición: abrirEditarHist(porcinoHist, h) */}
-        </div>
-      </td>
+<td>
+  <div style={{ display:'flex', gap:8 }}>
+    {h.alimentacion?._id ? (
+      <button
+        className="icon-btn"
+        onClick={() => abrirEditarHist(porcinoHist, h)}
+        title="Editar"
+      >
+        ✏️
+      </button>
+    ) : (
+      <span className="badge">No editable</span>
+    )}
+    <button
+      className="icon-btn danger"
+      onClick={() => onEliminarClick(porcinoHist._id, h._id)}
+      title="Eliminar"
+      disabled={!h._id}
+    >
+      🗑️
+    </button>
+  </div>
+</td>
     </tr>
   ))}
   {(!porcinoHist?.historialAlimentacion || porcinoHist.historialAlimentacion.length === 0) && (
@@ -421,13 +453,22 @@ export default function PorcinoCRUD() {
       </Modal>
 
       {/* Modal editar historial existente (placeholder UI, aún sin mutations GraphQL específicas) */}
-      <EditarHistorialModal
-        isOpen={editHistOpen}
-        onRequestClose={() => setEditHistOpen(false)}
-        porcino={porcinoEditRef}
-        registro={registroEdit}
-        onGuardado={() => qPorcinos.refetch()}
-      />
+<EditarHistorialModal
+  isOpen={editHistOpen}
+  onRequestClose={() => setEditHistOpen(false)}
+  porcino={porcinoEditRef}
+  registro={registroEdit}
+  onGuardado={(porcUpdated) => {
+    if (porcUpdated) {
+      setPorcinos((prev) => prev.map(p => (p._id === porcUpdated._id ? porcUpdated : p)));
+      setPorcinoHist((curr) => (curr && curr._id === porcUpdated._id ? porcUpdated : curr));
+      qAlims.refetch(); // ver stock actualizado
+    } else {
+      qPorcinos.refetch();
+      qAlims.refetch();
+    }
+  }}
+/>
     </div>
   );
 }

--- a/frontend/src/graphql/porcino.gql.js
+++ b/frontend/src/graphql/porcino.gql.js
@@ -10,7 +10,13 @@ export const Q_PORCINOS = gql`
       edad
       peso
       cliente { _id cedula nombres apellidos }
-      historialAlimentacion { dosis fecha nombreSnapshot }
+      historialAlimentacion {
+        _id
+        dosis
+        fecha
+        nombreSnapshot
+        alimentacion { _id nombre }
+      }
     }
   }
 `;
@@ -64,16 +70,28 @@ export const M_ALIMENTAR_PORCINO = gql`
     alimentarPorcino(input: $input) {
       _id
       identificacion
-      historialAlimentacion { dosis fecha nombreSnapshot }
+      historialAlimentacion {
+        _id
+        dosis
+        fecha
+        nombreSnapshot
+        alimentacion { _id nombre }
+      }
     }
   }
 `;
-export const M_EDITAR_HISTORIAL = gql`
-  mutation EditarHistorial($input: EditarHistorialInput!) {
-    editarHistorialAlimentacion(input: $input) {
+
+export const M_ELIMINAR_HISTORIAL = gql`
+  mutation EliminarHistorial($porcinoId: ID!, $historialId: ID!) {
+    eliminarHistorialAlimentacion(porcinoId: $porcinoId, historialId: $historialId) {
       _id
-      identificacion
-      historialAlimentacion { dosis fecha nombreSnapshot }
+      historialAlimentacion {
+        _id
+        dosis
+        fecha
+        nombreSnapshot
+        alimentacion { _id nombre }
+      }
     }
   }
 `;
@@ -83,20 +101,6 @@ export const M_ACTUALIZAR_HISTORIAL = gql`
     actualizarHistorialAlimentacion(porcinoId: $porcinoId, historialId: $historialId, data: $data) {
       _id
       historialAlimentacion { _id dosis fecha nombreSnapshot alimentacion { _id nombre } }
-    }
-  }
-`;
-export const M_ELIMINAR_HISTORIAL = gql`
-  mutation EliminarHistorial($porcinoId: ID!, $historialId: ID!) {
-    eliminarHistorialAlimentacion(porcinoId: $porcinoId, historialId: $historialId) {
-      _id
-      historialAlimentacion {
-  _id
-  dosis
-  fecha
-  nombreSnapshot
-  alimentacion { _id nombre }
-}
     }
   }
 `;


### PR DESCRIPTION
Historial ahora es editable solo si la alimentación existe; si no, queda en solo lectura con snapshot y solo opción de borrar, todo vía resolvers GraphQL y UI condicionada.

Mutations de historial ajustan stock correctamente en ediciones y eliminaciones, devuelven el Porcino poblado y permiten refrescar tabla y modal sin recargar.

Queries y UI se actualizaron para traer y usar la referencia anidada de alimentación por ítem del historial, desbloqueando el botón de edición cuando corresponde.

Se corrigieron errores de nullabilidad agregando resolver de campo para historial.alimentacion y populates anidados.

Se estandarizó cache/refetch en Apollo para refrescar tabla, modal y stock después de editar/eliminar.

Backend GraphQL
Query.porcinos y Query.porcino:

Se agregó populate('cliente') y populate('historialAlimentacion.alimentacion') para que alimentacion {_id, nombre} esté disponible en cada registro del historial.

Resolver de campo:

Se añadió HistorialAlimentacion.alimentacion con carga perezosa y retorno null cuando la referencia no existe, evitando “Cannot return null for non-nullable field Alimentacion.nombre”.

Mutation.actualizarHistorialAlimentacion:

Nueva validación “solo lectura” cuando el registro perdió su alimentación original.

Ajuste de stock por delta cuando no cambia alimentación; devolución y descuento al cambiar alimentación; actualización de snapshot nombre/descripcion.

Retorna el Porcino refrescado con populate anidado para que UI y cache reflejen el cambio.

Mutation.eliminarHistorialAlimentacion:

Devuelve stock si la referencia de alimento existe; si no, solo elimina el registro.